### PR TITLE
Make reporting human readable

### DIFF
--- a/lib/exref/mix/tasks/exref.ex
+++ b/lib/exref/mix/tasks/exref.ex
@@ -3,17 +3,55 @@ defmodule Mix.Tasks.Compile.Exref do
 
   @shortdoc "Check all function calls using xref"
 
+  @default_checks ~w/undefined_function_calls locals_not_used deprecated_function_calls/a
+
   def run(_args) do
     app_name = Mix.Project.config[:app] |> Atom.to_string
     ebin_dir = Path.join([Mix.Project.build_path, "lib", app_name, "ebin"]) |> String.to_char_list
-    results = :xref.d(ebin_dir)
-    Enum.each(results, &print_and_halt_on_nonempty/1)
+
+    results = for c <- @default_checks do
+      :xref_runner.check(c, %{dirs: [ebin_dir]})
+    end
+
+    results
+    |> List.flatten
+    |> print_and_raise_on_problems
   end
 
-  defp print_and_halt_on_nonempty({_, []}), do: nil
-  defp print_and_halt_on_nonempty({label, funcalls}) do
-    IO.puts("exref error: #{label}")
-    Enum.each(funcalls, fn f -> IO.puts("  #{inspect f}") end)
+  defp print_and_raise_on_problems([]), do: nil
+  defp print_and_raise_on_problems(problems) do
+    problems
+    |> Enum.map(&gen_comment/1)
+    |> Enum.each(&IO.puts/1)
+
     Mix.raise "Error in xref check! Please fix any errors and try again."
   end
+
+  defp gen_comment(xref_warn) do
+    %{filename: filename, line: line, source: source, check: check} = xref_warn
+    target = xref_warn[:target]
+
+    pos = case {filename, line} do
+            {"", _} -> ""
+            {_, 0}  -> "#{filename} "
+            {_, _}  -> "#{filename}:#{line} "
+          end
+
+    pos <> gen_comment_txt(check, source, target)
+  end
+
+  def gen_comment_txt(check, {sm, sf, sa}, tmfa) do
+    sm = sm |> to_string |> String.replace("Elixir.", "")
+    gen_comment_txt(check, "#{sm}.#{sf}/#{sa}", tmfa)
+  end
+  def gen_comment_txt(check, smfa, {tm, tf, ta}) do
+    tm = tm |> to_string |> String.replace("Elixir.", "")
+    gen_comment_txt(check, smfa, "#{tm}.#{tf}/#{ta}")
+  end
+  def gen_comment_txt(:undefined_function_calls, smfa, tmfa),  do: "#{smfa} calls undefined function #{tmfa}"
+  def gen_comment_txt(:undefined_functions, smfa, _tmfa),      do: "#{smfa} is not defined as a function"
+  def gen_comment_txt(:locals_not_used, smfa, _tmfa),          do: "#{smfa} is an unused local function"
+  def gen_comment_txt(:exports_not_used, smfa, _tmfa),         do: "#{smfa} is an unused export"
+  def gen_comment_txt(:deprecated_function_calls, smfa, tmfa), do: "#{smfa} calls deprecated function #{tmfa}"
+  def gen_comment_txt(:deprecated_functions, smfa, _tmfa),     do: "#{smfa} is deprecated"
 end

--- a/lib/exref/mix/tasks/exref.ex
+++ b/lib/exref/mix/tasks/exref.ex
@@ -40,18 +40,14 @@ defmodule Mix.Tasks.Compile.Exref do
     pos <> gen_comment_txt(check, source, target)
   end
 
-  def gen_comment_txt(check, {sm, sf, sa}, tmfa) do
-    sm = sm |> to_string |> String.replace("Elixir.", "")
-    gen_comment_txt(check, "#{sm}.#{sf}/#{sa}", tmfa)
-  end
-  def gen_comment_txt(check, smfa, {tm, tf, ta}) do
-    tm = tm |> to_string |> String.replace("Elixir.", "")
-    gen_comment_txt(check, smfa, "#{tm}.#{tf}/#{ta}")
-  end
-  def gen_comment_txt(:undefined_function_calls, smfa, tmfa),  do: "#{smfa} calls undefined function #{tmfa}"
-  def gen_comment_txt(:undefined_functions, smfa, _tmfa),      do: "#{smfa} is not defined as a function"
-  def gen_comment_txt(:locals_not_used, smfa, _tmfa),          do: "#{smfa} is an unused local function"
-  def gen_comment_txt(:exports_not_used, smfa, _tmfa),         do: "#{smfa} is an unused export"
-  def gen_comment_txt(:deprecated_function_calls, smfa, tmfa), do: "#{smfa} calls deprecated function #{tmfa}"
-  def gen_comment_txt(:deprecated_functions, smfa, _tmfa),     do: "#{smfa} is deprecated"
+  defp gen_comment_txt(check, {sm, sf, sa}, tmfa), do: gen_comment_txt(check, mfa_to_string(sm, sf, sa), tmfa)
+  defp gen_comment_txt(check, smfa, {tm, tf, ta}), do: gen_comment_txt(check, mfa, mfa_to_string(tm, tf, ta))
+  defp gen_comment_txt(:undefined_function_calls, smfa, tmfa),  do: "#{smfa} calls undefined function #{tmfa}"
+  defp gen_comment_txt(:undefined_functions, smfa, _tmfa),      do: "#{smfa} is not defined as a function"
+  defp gen_comment_txt(:locals_not_used, smfa, _tmfa),          do: "#{smfa} is an unused local function"
+  defp gen_comment_txt(:exports_not_used, smfa, _tmfa),         do: "#{smfa} is an unused export"
+  defp gen_comment_txt(:deprecated_function_calls, smfa, tmfa), do: "#{smfa} calls deprecated function #{tmfa}"
+  defp gen_comment_txt(:deprecated_functions, smfa, _tmfa),     do: "#{smfa} is deprecated"
+
+  defp mfa_to_string(m, f, a), do: "#{m |> to_string |> String.replace("Elixir.", "")}.#{f}/#{a}"
 end

--- a/lib/exref/mix/tasks/exref.ex
+++ b/lib/exref/mix/tasks/exref.ex
@@ -30,7 +30,6 @@ defmodule Mix.Tasks.Compile.Exref do
   defp gen_comment(xref_warn) do
     %{filename: filename, line: line, source: source, check: check} = xref_warn
     target = xref_warn[:target]
-
     pos = case {filename, line} do
             {"", _} -> ""
             {_, 0}  -> "#{filename} "
@@ -41,7 +40,7 @@ defmodule Mix.Tasks.Compile.Exref do
   end
 
   defp gen_comment_txt(check, {sm, sf, sa}, tmfa), do: gen_comment_txt(check, mfa_to_string(sm, sf, sa), tmfa)
-  defp gen_comment_txt(check, smfa, {tm, tf, ta}), do: gen_comment_txt(check, mfa, mfa_to_string(tm, tf, ta))
+  defp gen_comment_txt(check, smfa, {tm, tf, ta}), do: gen_comment_txt(check, smfa, mfa_to_string(tm, tf, ta))
   defp gen_comment_txt(:undefined_function_calls, smfa, tmfa),  do: "#{smfa} calls undefined function #{tmfa}"
   defp gen_comment_txt(:undefined_functions, smfa, _tmfa),      do: "#{smfa} is not defined as a function"
   defp gen_comment_txt(:locals_not_used, smfa, _tmfa),          do: "#{smfa} is an unused local function"

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Exref.Mixfile do
       elixir:          "~> 1.2",
       build_embedded:  Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps:            [],
+      deps:            deps,
       description:     description,
       package:         package,
       source_url:      @github_url,
@@ -34,6 +34,12 @@ defmodule Exref.Mixfile do
       maintainers: ["Shunsuke Kirino"],
       licenses:    ["MIT"],
       links:       %{"GitHub repository" => @github_url},
+    ]
+  end
+
+  defp deps do
+    [
+      {:xref_runner, github: "X4lldux/xref_runner", branch: "bugfix-for-52"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
 %{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"}}
+  "ex_doc": {:hex, :ex_doc, "0.11.4"},
+  "getopt": {:hex, :getopt, "0.8.2"},
+  "xref_runner": {:git, "https://github.com/X4lldux/xref_runner.git", "18dda55ee42a1f7525c8e03563cbde0da3abcb4f", [branch: "bugfix-for-52"]}}


### PR DESCRIPTION
Makes reports user friendlier, instead of having this:

```
$ mix compile.exref
exref error: undefined
  {{Mix.Tasks.Compile.Exref, :print_and_halt_on_nonempty, 1}, {Enum, :asdasd, 0}}
** (Mix) Error in xref check! Please fix any errors and try again.
```

we have this:

```
$ mix compile.exref
lib/exref/mix/tasks/exref.ex:21 Mix.Tasks.Compile.Exref.print_and_raise_on_problems/1 calls undefined function Enum.asdasd/0
** (Mix) Error in xref check! Please fix any errors and try again.
```

To achieve this, instead of bare _xref_, Inaka's _xref_runner_ is used. 
